### PR TITLE
Small change to welcome page and publications

### DIFF
--- a/content/home/welcome.md
+++ b/content/home/welcome.md
@@ -14,4 +14,4 @@ design:
 
 <br>
 
-Researching the evolutionary dynamics of accessory genomes and giant TEs in species of filamentous fungal, such as _Fusarium_.
+Researching the evolutionary dynamics of accessory genomes and giant TEs in species of filamentous fungi, such as _Fusarium_.

--- a/content/publication/doi-10-1073-pnas-2214521120/index.md
+++ b/content/publication/doi-10-1073-pnas-2214521120/index.md
@@ -2,14 +2,14 @@
 # Documentation: https://wowchemy.com/docs/managing-content/
 
 title:
-  <i>Starships</i> are active eukaryotic transposable elements mobilized by a
+  Starships are active eukaryotic transposable elements mobilized by a
   new family of tyrosine recombinases
 subtitle: ""
 summary: ""
 authors:
-  - Andrew S. Urquhart
-  - Aaron A. Vogan
-  - Donald M. Gardiner
+  - Andrew S Urquhart
+  - Aaron A Vogan
+  - Donald M Gardiner
   - Alexander Idnurm
 tags: []
 categories: []


### PR DESCRIPTION
Saw a misspelling(?) on the welcome page. 

Also, the latest publication looked a little odd. For example, when one clicked on Aaron's name it did not link to the same list of recent research as all his other papers due to the dot in "Aaron A. Vogan".